### PR TITLE
stripPhone fix and unit test

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log",
     "build": "tsc",
     "build:watch": "npm run build -- --watch",
-    "test": "jest --watch"
+    "test": "jest"
   },
   "engines": {
     "node": "18"

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log",
     "build": "tsc",
     "build:watch": "npm run build -- --watch",
-    "test": "jest"
+    "test": "jest --watch"
   },
   "engines": {
     "node": "18"

--- a/functions/src/definitions/common/utils.test.ts
+++ b/functions/src/definitions/common/utils.test.ts
@@ -9,6 +9,73 @@ describe("firestoreTimestampToYYYYMM should work correctly", () => {
   })
 })
 
+// Test strings are messages from actual Firestore. Phone numbers jumbled for anonymity.
+describe("stripPhone function", () => {
+  describe("when text contains a valid phone number to be extracted", () => {
+    describe("when includePlaceholder is set to false", () => {
+      it("should strip phone numbers from the original string", () => {
+        const testCases = [
+          { originalStr: "Phone call: 83294023", expectedStr: "Phone call: " },
+          {
+            originalStr:
+              "https://youtu.be/oglCjESHJ70?si=JznEryFFXUZ6y2ma ~Dayan +6583294023 Who are you ~SLTan米+6583294023 你是红桂桥Ada？ ~Dayan +6583294023 No",
+            expectedStr:
+              "https://youtu.be/oglCjESHJ70?si=JznEryFFXUZ6y2ma ~Dayan  Who are you ~SLTan米 你是红桂桥Ada？ ~Dayan  No",
+          },
+        ]
+
+        testCases.forEach(({ originalStr, expectedStr }) => {
+          expect(stripPhone(originalStr)).toEqual(expectedStr)
+        })
+      })
+    }),
+      describe("when includePlaceholder is set to true", () => {
+        it("should replace phone numbers with placeholder from the original string", () => {
+          const testCases = [
+            {
+              originalStr: "Phone call: 83294023",
+              expectedStr: "Phone call: <PHONE_NUM>",
+            },
+            {
+              originalStr:
+                "https://youtu.be/oglCjESHJ70?si=JznEryFFXUZ6y2ma ~Dayan +6588888888 Who are you ~SLTan米+6599999999 你是红桂桥Ada？ ~Dayan +6589898989 No",
+              expectedStr:
+                "https://youtu.be/oglCjESHJ70?si=JznEryFFXUZ6y2ma ~Dayan <PHONE_NUM> Who are you ~SLTan米<PHONE_NUM> 你是红桂桥Ada？ ~Dayan <PHONE_NUM> No",
+            },
+            {
+              originalStr: "you ~SLTan米+6583294023",
+              expectedStr: "you ~SLTan米<PHONE_NUM>",
+            },
+          ]
+          testCases.forEach(({ originalStr, expectedStr }) => {
+            expect(stripPhone(originalStr, true)).toEqual(expectedStr)
+          })
+        })
+      })
+  }),
+    describe("when text does not contain a valid phone number", () => {
+      it("should return the original string", () => {
+        const testCases = [
+          {
+            originalStr:
+              "Here are some signs that this message is a scam: 1) The message claims that a delivery failed and that goods have been returned to a collection center, but it does not provide any specific details about the delivery or the goods in question. 2) The message includes a shortened URL (https://goo.su/PTvJGC), which could potentially lead to a malicious website or phishing attempt. 3) The message creates a sense of urgency by asking the recipient to schedule a new delivery immediately, which could be a tactic to pressure the recipient into clicking the link without thinking critically about its legitimacy.",
+            expectedStr:
+              "Here are some signs that this message is a scam: 1) The message claims that a delivery failed and that goods have been returned to a collection center, but it does not provide any specific details about the delivery or the goods in question. 2) The message includes a shortened URL (https://goo.su/PTvJGC), which could potentially lead to a malicious website or phishing attempt. 3) The message creates a sense of urgency by asking the recipient to schedule a new delivery immediately, which could be a tactic to pressure the recipient into clicking the link without thinking critically about its legitimacy.",
+          },
+          {
+            originalStr:
+              "https://www.instagram.com/reel/CvsSNvzJH38/?igshid=MzRlODBiNWFlZA== is this for real?",
+            expectedStr:
+              "https://www.instagram.com/reel/CvsSNvzJH38/?igshid=MzRlODBiNWFlZA== is this for real?",
+          },
+        ]
+        testCases.forEach(({ originalStr, expectedStr }) => {
+          expect(stripPhone(originalStr)).toEqual(expectedStr)
+        })
+      })
+    })
+})
+
 describe("stripUrl should strip URLs correctly", () => {
   test("should strip standalone URLs", () => {
     const standaloneUrls = [

--- a/functions/src/definitions/common/utils.ts
+++ b/functions/src/definitions/common/utils.ts
@@ -49,22 +49,29 @@ async function checkMessageId(messageId: string) {
 }
 
 function stripPhone(originalStr: string, includePlaceholder = false) {
-  const phoneNumbers = findPhoneNumbersInText(originalStr)
-  let newStr = originalStr
-  let offset = 0
+  let transformedString = originalStr
+
+  const maxTransformsThreshold = 30
+  let transformationsCount = 0
+
   const placeholder = includePlaceholder ? "<PHONE_NUM>" : ""
-  phoneNumbers.forEach((phoneNumber) => {
-    const { startsAt, endsAt } = phoneNumber
-    const adjustedStartsAt = startsAt - offset
-    const adjustedEndsAt = endsAt - offset
-    newStr =
-      newStr.slice(0, adjustedStartsAt) +
+
+  while (
+    transformationsCount < maxTransformsThreshold &&
+    findPhoneNumbersInText(transformedString).length !== 0
+  ) {
+    const currentModification = findPhoneNumbersInText(transformedString)[0]
+    const { startsAt, endsAt } = currentModification
+
+    transformedString =
+      transformedString.slice(0, startsAt) +
       placeholder +
-      newStr.slice(adjustedEndsAt)
-    offset += endsAt - startsAt
-  })
-  newStr = newStr.replace(/[0-9]{7,}/g, placeholder)
-  return newStr
+      transformedString.slice(endsAt)
+
+    transformationsCount++
+  }
+  transformedString = transformedString.replace(/[0-9]{7,}/g, placeholder)
+  return transformedString
 }
 
 function checkUrlPresence(originalStr: string): boolean {

--- a/functions/src/definitions/common/utils.ts
+++ b/functions/src/definitions/common/utils.ts
@@ -48,30 +48,19 @@ async function checkMessageId(messageId: string) {
   return messageSnap.exists
 }
 
-function stripPhone(originalStr: string, includePlaceholder = false) {
-  let transformedString = originalStr
+function stripPhone(text: string, includePlaceholder = false): string {
+  if (findPhoneNumbersInText(text).length === 0) {
+    return text.replace(/[0-9]{7,}/g, includePlaceholder ? "<PHONE_NUM>" : "")
+  }
 
-  const maxTransformsThreshold = 30
-  let transformationsCount = 0
+  const currentModification = findPhoneNumbersInText(text)[0]
+  const { startsAt, endsAt } = currentModification
 
   const placeholder = includePlaceholder ? "<PHONE_NUM>" : ""
 
-  while (
-    transformationsCount < maxTransformsThreshold &&
-    findPhoneNumbersInText(transformedString).length !== 0
-  ) {
-    const currentModification = findPhoneNumbersInText(transformedString)[0]
-    const { startsAt, endsAt } = currentModification
+  text = text.slice(0, startsAt) + placeholder + text.slice(endsAt)
 
-    transformedString =
-      transformedString.slice(0, startsAt) +
-      placeholder +
-      transformedString.slice(endsAt)
-
-    transformationsCount++
-  }
-  transformedString = transformedString.replace(/[0-9]{7,}/g, placeholder)
-  return transformedString
+  return stripPhone(text, includePlaceholder)
 }
 
 function checkUrlPresence(originalStr: string): boolean {


### PR DESCRIPTION
Added unit test for `stripPhone` utility function.

While working on unit tests I discovered a test case that wasn't working as documented in Issue #230.

Before refactoring the function, I performed some validations to make sure the `findPhoneNumbersInText` function was working as intended. 

```js
import { findPhoneNumbersInText } from "libphonenumber-js"

const str =
  "https://youtu.be/oglCjESHJ70?si=JznEryFFXUZ6y2ma ~Dayan +6583294024 Who are you ~SLTan米+6583294023 你是红桂桥Ada？ ~Dayan +6583294023 No"

console.log(findPhoneNumbersInText(str))

console.log(
  `56: ${str.charAt(56)}; 67: ${str.charAt(67)}; Slice: ${str.slice(56, 67)}`
)

console.log(
  `87: ${str.charAt(87)}; 98: ${str.charAt(98)}; Slice: ${str.slice(87, 98)}`
)

console.log(
  `116: ${str.charAt(116)}; 127: ${str.charAt(127)}; Slice: ${str.slice(
    116,
    127
  )}`
)
```

yielded

```
56: +; 67:  ; Slice: +6583294024
87: +; 98:  ; Slice: +6583294023
116: +; 127:  ; Slice: +6583294023
```

Hence, there is no issue.

To simplify the function without the need to manually juggle indices, I refactored it in such a way that it takes the nearest phone number to be updated, updates it, reassigns a "new" string and repeat until there are no longer any numbers detected. A threshold value was also set to minimise the risk of an infinite being introduced for whatever reason (e.g. it couldn't format stuff properly and a number always remains detected)