### PR TITLE
Bug/handle unsure and error properly

### DIFF
--- a/checkers-app/src/components/dashboard/index.tsx
+++ b/checkers-app/src/components/dashboard/index.tsx
@@ -12,7 +12,7 @@ export default function Dashboard() {
   const [isLoading, setIsLoading] = useState(false);
   const { checkerId, pendingCount, setPendingCount } = useUser();
   const [totalVotes, setTotalVotes] = useState<number>(0);
-  const [accuracyRate, setAccuracyRate] = useState<number>(0);
+  const [accuracyRate, setAccuracyRate] = useState<number | null>(0);
   const [avgResponseTime, setAvgResponseTime] = useState<number>(0);
   const [peopleHelped, setPeopleHelped] = useState<number>(0);
 
@@ -61,12 +61,14 @@ export default function Dashboard() {
         <StatCard
           name="average accuracy rate"
           img_src="/accuracy.png"
-          stat={`${(accuracyRate * 100).toFixed(2)}%`}
+          stat={
+            accuracyRate === null ? "NA" : `${(accuracyRate * 100).toFixed(1)}%`
+          }
         />
         <StatCard
           name="average response time"
           img_src="/response.png"
-          stat={`${avgResponseTime.toFixed(2)} mins`}
+          stat={`${avgResponseTime.toFixed(0)} mins`}
         />
         <StatCard
           name="people helped"

--- a/checkers-app/src/components/myvotes/MessageCard.tsx
+++ b/checkers-app/src/components/myvotes/MessageCard.tsx
@@ -1,6 +1,6 @@
 import { VoteSummary } from "../../types";
 import { useNavigate } from "react-router-dom";
-import { PencilIcon } from "@heroicons/react/20/solid";
+import { PencilIcon, QuestionMarkCircleIcon } from "@heroicons/react/20/solid";
 import "./MessageCard.css";
 
 interface MessageCardProps {
@@ -20,23 +20,6 @@ const colours: ColourMap = {
   DEFAULT: "primary-color",
   WAITING: "waiting-color",
 };
-
-// function getCategory(msg: Message): string {
-//     if (msg.voteRequests.category == null) {
-//         return "PENDING";
-//     }
-//     else if (!msg.isAssessed && msg.voteRequests.category != null) {
-//         return "WAITING";
-//     }
-//     else {
-//         if (msg.isMatch) {
-//             return "CORRECT"
-//         }
-//         else {
-//             return "INCORRECT"
-//         }
-//     }
-// }
 
 function dateToDateString(date: Date | null): string {
   // Parse the ISO string into a Date object
@@ -84,6 +67,7 @@ export default function MessageCard(props: MessageCardProps) {
     //caption,
     needsReview,
     isAssessed,
+    isUnsure,
     firestorePath,
   } = props.voteSummary;
   const status = props.status;
@@ -98,6 +82,49 @@ export default function MessageCard(props: MessageCardProps) {
 
   const textStyle = "font-normal"; //add bold in future
 
+  function renderStatusDot() {
+    // Checking if the status is 'voted'
+    if (status === "voted") {
+      if (isAssessed) {
+        if (isUnsure) {
+          // Is unsure
+          return (
+            <div className="w-1/12 flex items-center justify-center">
+              <QuestionMarkCircleIcon className="h-4 w-4" />
+            </div>
+          );
+        } else {
+          if (needsReview) {
+            return (
+              <div className="w-1/12 flex items-center justify-center">
+                <div
+                  className={`w-4 h-4 rounded-full bg-${colours.INCORRECT}`}
+                ></div>
+              </div>
+            );
+          } else {
+            return (
+              <div className="w-1/12 flex items-center justify-center">
+                <div
+                  className={`w-4 h-4 rounded-full bg-${colours.CORRECT}`}
+                ></div>
+              </div>
+            );
+          }
+        }
+      } else {
+        // Not assessed
+        return (
+          <div className="w-1/12 flex items-center justify-center">
+            <PencilIcon className="h-4 w-4" />
+          </div>
+        );
+      }
+    }
+    // If none of the conditions match, return null
+    return null;
+  }
+
   return (
     <div
       className="flex border-b border-gray-500 h-16 hover-shadow dark:bg-dark-background-color"
@@ -105,23 +132,7 @@ export default function MessageCard(props: MessageCardProps) {
     >
       {/* Coloured dot if needs review*/}
 
-      {isAssessed && needsReview && status === "voted" && (
-        <div className="w-1/12 flex items-center justify-center">
-          <div className={`w-4 h-4 rounded-full bg-${colours.INCORRECT}`}></div>
-        </div>
-      )}
-
-      {isAssessed && !needsReview && status === "voted" && (
-        <div className="w-1/12 flex items-center justify-center">
-          <div className={`w-4 h-4 rounded-full bg-${colours.CORRECT}`}></div>
-        </div>
-      )}
-
-      {!isAssessed && status === "voted" && (
-        <div className="w-1/12 flex items-center justify-center">
-          <PencilIcon className="h-4 w-4" />
-        </div>
-      )}
+      {renderStatusDot()}
 
       {/* Message content */}
       <div className="w-11/12 p-2">

--- a/functions/src/definitions/api/handlers/getChecker.ts
+++ b/functions/src/definitions/api/handlers/getChecker.ts
@@ -102,8 +102,8 @@ const getCheckerHandler = async (req: Request, res: Response) => {
     const accurateCount = results.filter(
       (d) => d !== null && d.isAccurate
     ).length
-    const totalAssessedCount = results.filter(
-      (d) => d !== null && d.isAssessed
+    const totalAssessedAndNonUnsureCount = results.filter(
+      (d) => d !== null && d.isAssessed && d.isAccurate !== null
     ).length
     const totalCount = results.filter((d) => d !== null).length
     //calculate people helped
@@ -126,7 +126,9 @@ const getCheckerHandler = async (req: Request, res: Response) => {
     const averageResponseTime = totalResponseTime / (totalCount || 1)
 
     const accuracyRate =
-      totalAssessedCount === 0 ? 1 : accurateCount / totalAssessedCount
+      totalAssessedAndNonUnsureCount === 0
+        ? null
+        : accurateCount / totalAssessedAndNonUnsureCount
     const returnData: Checker = {
       name: checkerData.name,
       type: checkerData.type,

--- a/functions/src/definitions/api/handlers/getCheckerVotes.ts
+++ b/functions/src/definitions/api/handlers/getCheckerVotes.ts
@@ -97,8 +97,9 @@ const getCheckerVotesHandler = async (req: Request, res: Response) => {
         const caption = latestInstanceSnap.get("caption") ?? null
         const isAssessed = parentMessageSnap.get("isAssessed") ?? false
         const firestorePath = doc.ref.path
-        const needsReview =
-          isAssessed && checkAccuracy(parentMessageSnap, doc) === false
+        const isCorrect = checkAccuracy(parentMessageSnap, doc)
+        const needsReview = isAssessed && isCorrect === false
+        const isUnsure = isCorrect === null //either unsure or some other type of error
 
         const returnObject: VoteSummary = {
           category,
@@ -110,6 +111,7 @@ const getCheckerVotesHandler = async (req: Request, res: Response) => {
           caption,
           needsReview,
           isAssessed,
+          isUnsure,
           firestorePath,
         }
         return returnObject

--- a/functions/src/definitions/api/handlers/getVote.ts
+++ b/functions/src/definitions/api/handlers/getVote.ts
@@ -45,6 +45,13 @@ const getVoteHandler = async (req: Request, res: Response) => {
 
     const latestType = latestInstanceSnap.get("type") ?? "text"
 
+    const sender = latestInstanceSnap.get("from") ?? "Unknown"
+
+    //mask all but last 4 characters of sender
+
+    const maskedSender =
+      sender != "Unknown" ? sender.replace(/.(?=.{4})/g, "*") : sender
+
     const storageBucketUrl = latestInstanceSnap.get("storageUrl")
     const signedUrl =
       latestType === "image" ? await getSignedUrl(storageBucketUrl) : null
@@ -123,6 +130,7 @@ const getVoteHandler = async (req: Request, res: Response) => {
         latestType === "image" ? latestInstanceSnap.get("caption") : null,
       signedImageUrl: signedUrl,
       category: voteRequestSnap.get("category"),
+      sender: maskedSender,
       truthScore: isLegacy
         ? voteRequestSnap.get("vote")
         : voteRequestSnap.get("truthScore"),

--- a/functions/src/definitions/api/interfaces.ts
+++ b/functions/src/definitions/api/interfaces.ts
@@ -77,6 +77,7 @@ interface VoteSummaryApiResponse {
 interface Vote {
   type: "image" | "text"
   text: string | null //only for type text
+  sender: string
   caption: string | null //only for type image
   signedImageUrl: string | null //only for type image
   category: string | null

--- a/functions/src/definitions/api/interfaces.ts
+++ b/functions/src/definitions/api/interfaces.ts
@@ -64,6 +64,7 @@ interface VoteSummary {
   caption: string | null //only for type image
   needsReview: boolean //if the vote differs from the majority
   isAssessed: boolean //if the message is assessed
+  isUnsure: boolean //if the final assessed category ended as unsure
   firestorePath: string
 }
 

--- a/functions/src/definitions/api/interfaces.ts
+++ b/functions/src/definitions/api/interfaces.ts
@@ -86,7 +86,7 @@ interface Vote {
 
 interface last30DaysStats {
   totalVoted: number
-  accuracyRate: number
+  accuracyRate: number | null
   averageResponseTime: number
   peopleHelped: number
 }

--- a/functions/src/definitions/common/counters.ts
+++ b/functions/src/definitions/common/counters.ts
@@ -28,4 +28,58 @@ const getCount = async function (docRef: DocumentReference, type: string) {
   return count
 }
 
-export { getCount, incrementCounter }
+const getVoteCounts = async function (messageRef: DocumentReference) {
+  const totalVoteRequestQuery = messageRef
+    .collection("voteRequests")
+    .count()
+    .get()
+  const [
+    responsesCount,
+    errorCount,
+    irrelevantCount,
+    scamCount,
+    illicitCount,
+    infoCount,
+    spamCount,
+    legitimateCount,
+    unsureCount,
+    satireCount,
+    voteTotal,
+    voteRequestCountSnapshot,
+  ] = await Promise.all([
+    getCount(messageRef, "responses"),
+    getCount(messageRef, "error"),
+    getCount(messageRef, "irrelevant"),
+    getCount(messageRef, "scam"),
+    getCount(messageRef, "illicit"),
+    getCount(messageRef, "info"),
+    getCount(messageRef, "spam"),
+    getCount(messageRef, "legitimate"),
+    getCount(messageRef, "unsure"),
+    getCount(messageRef, "satire"),
+    getCount(messageRef, "totalVoteScore"),
+    totalVoteRequestQuery,
+  ])
+  const totalVoteRequestsCount = voteRequestCountSnapshot.data().count ?? 0
+  const factCheckerCount = totalVoteRequestsCount - errorCount //don't count "error" votes in number of fact checkers, as this will slow the replies unnecessarily.
+  const validResponsesCount = responsesCount - errorCount //can remove in future and replace with nonErrorCount
+  const susCount = scamCount + illicitCount
+  return {
+    responsesCount,
+    errorCount,
+    irrelevantCount,
+    scamCount,
+    illicitCount,
+    infoCount,
+    spamCount,
+    legitimateCount,
+    unsureCount,
+    satireCount,
+    voteTotal,
+    validResponsesCount,
+    susCount,
+    factCheckerCount,
+  }
+}
+
+export { getCount, incrementCounter, getVoteCounts }

--- a/integration-tests/checkmate.postman_collection.json
+++ b/integration-tests/checkmate.postman_collection.json
@@ -3009,7 +3009,7 @@
 											"    const BUTTON_ANOTHER_UPDATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.BUTTON_ANOTHER_UPDATE.en\");\r",
 											"    const wamid = pm.variables.get(\"whatsapp_id_11\")\r",
 											"    const instanceId = pm.variables.get(\"spamInstanceId\")\r",
-											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.33\").replace(\"{{prelim_assessment}}\",\"spam🚧\").replace(\"{{info_placeholder}}\",\"\")\r",
+											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.3\").replace(\"{{prelim_assessment}}\",\"spam🚧\").replace(\"{{info_placeholder}}\",\"\")\r",
 											"    const expected = {\r",
 											"            \"hostname\": \"resultserver\",\r",
 											"            \"path\": \"/v15.0/WHATSAPP_TEST_USER_BOT_PHONE_NUMBER_ID/messages\",\r",
@@ -3046,7 +3046,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -3055,7 +3056,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -3154,7 +3156,7 @@
 											"    const BUTTON_ANOTHER_UPDATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.BUTTON_ANOTHER_UPDATE.en\")\r",
 											"    const instanceId = pm.variables.get(\"spamInstanceId\")\r",
 											"    const wamid = pm.variables.get(\"whatsapp_id_11\")\r",
-											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.33\").replace(\"{{prelim_assessment}}\",\"spam🚧\").replace(\"{{info_placeholder}}\",\"\").replace(\"{{get_feedback}}\",\"\")\r",
+											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.3\").replace(\"{{prelim_assessment}}\",\"spam🚧\").replace(\"{{info_placeholder}}\",\"\").replace(\"{{get_feedback}}\",\"\")\r",
 											"    const expected = {\r",
 											"            \"hostname\": \"resultserver\",\r",
 											"            \"path\": \"/v15.0/WHATSAPP_TEST_USER_BOT_PHONE_NUMBER_ID/messages\",\r",
@@ -3191,7 +3193,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -3200,7 +3203,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -3863,7 +3867,7 @@
 											"    const INTERIM_TEMPLATE_UNSURE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.INTERIM_TEMPLATE_UNSURE.en\");\r",
 											"    const BUTTON_ANOTHER_UPDATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.BUTTON_ANOTHER_UPDATE.en\")\r",
 											"    const instanceId = pm.variables.get(\"spamInstanceId\")\r",
-											"    const interimResponse = INTERIM_TEMPLATE_UNSURE.replace(\"{{%voted}}\", \"66.67\")\r",
+											"    const interimResponse = INTERIM_TEMPLATE_UNSURE.replace(\"{{%voted}}\", \"66.7\")\r",
 											"    const wamid = pm.variables.get(\"whatsapp_id_11\")\r",
 											"    const expected = {\r",
 											"            \"hostname\": \"resultserver\",\r",
@@ -3900,7 +3904,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -3909,7 +3914,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -5083,7 +5089,7 @@
 											"        \"path\": \"/v15.0/WHATSAPP_TEST_USER_BOT_PHONE_NUMBER_ID/messages\",\r",
 											"        \"body\": {\r",
 											"            \"text\": {\r",
-											"                \"body\": \"66.67% of our CheckMates felt this was *spam🚧*. 33.33% felt this was *legitimate✅*.\",\r",
+											"                \"body\": \"66.7% of our CheckMates felt this was *spam🚧*. 33.3% felt this was *legitimate✅*.\",\r",
 											"                \"preview_url\": false\r",
 											"            },\r",
 											"            \"to\": USER_1_NUMBER,\r",
@@ -5098,7 +5104,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -5107,7 +5114,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -5762,6 +5770,7 @@
 											"        },\r",
 											"        \"method\": \"POST\"\r",
 											"    }\r",
+											"    console.log(JSON.stringify(expected, null, 2))\r",
 											"    var jsonData = pm.response.json();\r",
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
@@ -6225,7 +6234,7 @@
 											"    const BUTTON_ANOTHER_UPDATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.BUTTON_ANOTHER_UPDATE.en\")\r",
 											"    const instanceId = pm.variables.get(\"infoInstanceId\")\r",
 											"    const wamid = pm.variables.get(\"whatsapp_id_19\")\r",
-											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.33\").replace(\"{{prelim_assessment}}\",\"untrue❌\").replace(\"{{info_placeholder}}\",INFO_PLACEHOLDER.replace(\"{{score}}\",\"1.00\"))\r",
+											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.3\").replace(\"{{prelim_assessment}}\",\"untrue❌\").replace(\"{{info_placeholder}}\",INFO_PLACEHOLDER.replace(\"{{score}}\",\"1.0\"))\r",
 											"    const expected = {\r",
 											"            \"hostname\": \"resultserver\",\r",
 											"            \"path\": \"/v15.0/WHATSAPP_TEST_USER_BOT_PHONE_NUMBER_ID/messages\",\r",
@@ -6264,7 +6273,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -6273,7 +6283,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -7191,7 +7202,7 @@
 											"    const STATS_TEMPLATE_1 = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.STATS_TEMPLATE_1.en\")\r",
 											"    const PLACEHOLDER_MISLEADING = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.PLACEHOLDER_MISLEADING.en\")\r",
 											"    const INFO_PLACEHOLDER = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.INFO_PLACEHOLDER.en\")\r",
-											"    const expectedBody = STATS_TEMPLATE_1.replace(\"{{top}}\", \"100.00\").replace(\"{{category}}\",PLACEHOLDER_MISLEADING).replace(\"{{info_placeholder}}\",INFO_PLACEHOLDER.replace(\"{{score}}\",\"2.33\"))\r",
+											"    const expectedBody = STATS_TEMPLATE_1.replace(\"{{top}}\", \"100.0\").replace(\"{{category}}\",PLACEHOLDER_MISLEADING).replace(\"{{info_placeholder}}\",INFO_PLACEHOLDER.replace(\"{{score}}\",\"2.3\"))\r",
 											"    //we not using the template for this, its hardcoded.\r",
 											"    const expected = {\r",
 											"        \"hostname\": \"resultserver\",\r",
@@ -7213,7 +7224,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -7222,7 +7234,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -8557,7 +8570,7 @@
 											"    const INTERIM_TEMPLATE_UNSURE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.INTERIM_TEMPLATE_UNSURE.en\");\r",
 											"    const BUTTON_ANOTHER_UPDATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.BUTTON_ANOTHER_UPDATE.en\")\r",
 											"    const instanceId = pm.variables.get(\"unsureInstanceId\")\r",
-											"    const interimResponse = INTERIM_TEMPLATE_UNSURE.replace(\"{{%voted}}\", \"33.33\")\r",
+											"    const interimResponse = INTERIM_TEMPLATE_UNSURE.replace(\"{{%voted}}\", \"33.3\")\r",
 											"    const expected = {\r",
 											"            \"hostname\": \"resultserver\",\r",
 											"            \"path\": \"/v15.0/WHATSAPP_TEST_USER_BOT_PHONE_NUMBER_ID/messages\",\r",
@@ -8594,7 +8607,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -8603,7 +8617,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -8873,7 +8888,7 @@
 											"    const INTERIM_TEMPLATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.INTERIM_TEMPLATE.en\");\r",
 											"    const BUTTON_ANOTHER_UPDATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.BUTTON_ANOTHER_UPDATE.en\")\r",
 											"    const instanceId = pm.variables.get(\"unsureInstanceId\")\r",
-											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.33\").replace(\"{{prelim_assessment}}\",\"legitimate✅\").replace(\"{{info_placeholder}}\",\"\")\r",
+											"    const interimResponse = INTERIM_TEMPLATE.replace(\"{{%voted}}\", \"33.3\").replace(\"{{prelim_assessment}}\",\"legitimate✅\").replace(\"{{info_placeholder}}\",\"\")\r",
 											"    const expected = {\r",
 											"            \"hostname\": \"resultserver\",\r",
 											"            \"path\": \"/v15.0/WHATSAPP_TEST_USER_BOT_PHONE_NUMBER_ID/messages\",\r",
@@ -8910,7 +8925,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -8919,7 +8935,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -9573,7 +9590,7 @@
 											"    const INTERIM_TEMPLATE_UNSURE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.INTERIM_TEMPLATE_UNSURE.en\");\r",
 											"    const BUTTON_ANOTHER_UPDATE = pm.variables.get(\"__CONSTANTS__.USER_BOT_RESPONSES.BUTTON_ANOTHER_UPDATE.en\");\r",
 											"    const instanceId = pm.variables.get(\"unsureInstanceId\")\r",
-											"    const interimResponse = INTERIM_TEMPLATE_UNSURE.replace(\"{{%voted}}\", \"66.67\")\r",
+											"    const interimResponse = INTERIM_TEMPLATE_UNSURE.replace(\"{{%voted}}\", \"66.7\")\r",
 											"\r",
 											"    const expected = {\r",
 											"            \"hostname\": \"resultserver\",\r",
@@ -9611,7 +9628,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -9621,7 +9639,8 @@
 											"// Allow time for firestore onUpdate event to complete\r",
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -10395,7 +10414,7 @@
 											"        \"path\": \"/v15.0/WHATSAPP_TEST_USER_BOT_PHONE_NUMBER_ID/messages\",\r",
 											"        \"body\": {\r",
 											"            \"text\": {\r",
-											"                \"body\": \"33.33% of our CheckMates felt this was *spam🚧*. 33.33% felt this was *misleading⚠️*, with an average score of 3.00 on a scale of 1-5 (5 = completely true).\",\r",
+											"                \"body\": \"33.3% of our CheckMates felt this was *spam🚧*. 33.3% felt this was *misleading⚠️*, with an average score of 3.0 on a scale of 1-5 (5 = completely true).\",\r",
 											"                \"preview_url\": false\r",
 											"            },\r",
 											"            \"to\": USER_1_NUMBER,\r",
@@ -10410,7 +10429,8 @@
 											"    pm.expect(jsonData).to.eql(expected);\r",
 											"});"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -10419,7 +10439,8 @@
 										"exec": [
 											"setTimeout(() => {}, 3000);"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],


### PR DESCRIPTION
## Issues
- Resolves #271 
- Resolves #272 
- Resolves #275 
- Partially addresses #277 

## Summary
- Refactored the get counts into its own functions in counters.ts
- Updated getChecker endpoint to calculate the accuracy correctly by removing those with accuracy == null (final category is assessed or other exception states) from the denominator
- Properly remove "error" votes from denominator when determining base of valid votes, and number of checkers
- Updated voteSummary to include isUnsure, and frontend to display different icon for it.
- Switched 2d.p display on floats to 1 or less d.p based on feedback
- Display NA for accuracy rate if no messages assessed in last 30 days, rather than 100%
- Updated tests accordingly