### PR TITLE
send truth score of null when category is not info

### DIFF
--- a/checkers-app/src/components/vote/VoteCategories.tsx
+++ b/checkers-app/src/components/vote/VoteCategories.tsx
@@ -89,7 +89,7 @@ export default function VoteCategories(Prop: PropType) {
   const handleSubmitVote = (category: string, truthScore: number | null) => {
     if (messageId && voteRequestId) {
       //call api to update vote
-      patchVote(messageId, voteRequestId, category, truthScore)
+      patchVote(messageId, voteRequestId, category, category === "info" ? truthScore : null)
         .then(() => {
           incrementSessionVotedCount();
           navigate("/votes");
@@ -106,9 +106,8 @@ export default function VoteCategories(Prop: PropType) {
         <>
           <Button
             className={`flex flex-row items-center justify-start gap-2 max-w-md space-x-3 text-sm
-            ${
-              category === cat.name ? "bg-primary-color3" : "bg-primary-color"
-            }`}
+            ${category === cat.name ? "bg-primary-color3" : "bg-primary-color"
+              }`}
             key={index}
             onClick={() => handleVote(cat.name)}
           >


### PR DESCRIPTION
## Issues
- Resolves #280 

## Root Cause
- Backend patchVotesRequest handler returns 400 under the following circumstance
``` 
if (category !== "info" && truthScore != null) {
    return res
      .status(400)
      .send("Truthscore can only be submitted for info category")
  }
```
- But frontend currently doesn't clear truth score or set it to null if a non-info category is submitted.

## Fix
- Make frontend submit null truth score if non-info category is submitted