### PR TITLE
Add secret name to voteRequestUpdate

### DIFF
--- a/functions/src/definitions/eventHandlers/onVoteRequestUpdate.ts
+++ b/functions/src/definitions/eventHandlers/onVoteRequestUpdate.ts
@@ -26,7 +26,11 @@ const db = admin.firestore()
 const onVoteRequestUpdateV2 = onDocumentUpdated(
   {
     document: "messages/{messageId}/voteRequests/{voteRequestId}",
-    secrets: ["WHATSAPP_CHECKERS_BOT_PHONE_NUMBER_ID", "WHATSAPP_TOKEN"],
+    secrets: [
+      "WHATSAPP_CHECKERS_BOT_PHONE_NUMBER_ID",
+      "WHATSAPP_TOKEN",
+      "TELEGRAM_CHECKER_BOT_TOKEN",
+    ],
   },
   async (event) => {
     // Grab the current value of what was written to Firestore.


### PR DESCRIPTION
Previously telegram reply markup was not updating properly.

Basically voteRequestUpdate didnt have access to the secret.