### PR TITLE
do not execute if it's ai type

### DIFF
--- a/functions/src/definitions/eventHandlers/onCheckerUpdate.ts
+++ b/functions/src/definitions/eventHandlers/onCheckerUpdate.ts
@@ -30,6 +30,7 @@ const onCheckerUpdateV2 = onDocumentUpdated(
     const postChangeData = postChangeSnap.data() as CheckerData
 
     if (
+      postChangeData.type === "ai" ||
       !postChangeData.programData.isOnProgram ||
       postChangeData.programData.programEnd != null
     ) {


### PR DESCRIPTION
Bugfix as ai type checker data object does not contain programData, which is causing errors on this line !postChangeData.programData.isOnProgram 