### PR TITLE
open onboarding links in new window

### DIFF
--- a/checkers-app/src/pages/Onboarding.tsx
+++ b/checkers-app/src/pages/Onboarding.tsx
@@ -67,6 +67,7 @@ const StepTwo = () => {
       <br />
       <a
         className="underline text-checkLink"
+        target="_blank"
         href="https://bit.ly/checkmate-privacy"
       >
         https://bit.ly/checkmate-privacy
@@ -87,6 +88,7 @@ const StepThree = () => {
       <p>
         <a
           className="underline text-checkLink"
+          target="_blank"
           href="https://bit.ly/checkmates-quiz)"
         >
           https://bit.ly/checkmates-quiz
@@ -114,6 +116,7 @@ const StepFour = () => {
       <p>
         <a
           className="underline text-checkLink"
+          target="_blank"
           href="https://bit.ly/checkmates-groupchat)"
         >
           https://bit.ly/checkmates-groupchat
@@ -128,6 +131,7 @@ const StepFour = () => {
       <p>
         <a
           className="underline text-checkLink"
+          target="_blank"
           href="https://bit.ly/checkmates-wiki)"
         >
           https://bit.ly/checkmates-wiki


### PR DESCRIPTION
## Issue

- When onboarding, checkers who click on links (e.g. privacy policy or quiz) will open them in the Telegram webapp. Thereafter, they cannot navigate back to the onboarding page to continue as telegram webapp has no back gesture built in, or a back button.

## Solution
- Made all anchor tags have target="_blank"