### PR TITLE
renamed to incorrect usage

### DIFF
--- a/checkers-app/src/components/vote/VoteTags.tsx
+++ b/checkers-app/src/components/vote/VoteTags.tsx
@@ -5,7 +5,7 @@ import { TooltipWithHelperIcon } from "../common/ToolTip";
 
 const options = [
   { value: "generated", label: "🤖 AI Generated" },
-  { value: "incorrect", label: "❌ Incorrect" },
+  { value: "incorrect", label: "❌ Incorrect Usage" },
 ];
 
 interface VoteTagsProps {


### PR DESCRIPTION
## Issue
- Tag called "incorrect" not informative

## Solution
- Changed to incorrect usage