### PR TITLE
handle missing numberpoint scale

### DIFF
--- a/checkers-app/src/components/vote/InfoOptions.tsx
+++ b/checkers-app/src/components/vote/InfoOptions.tsx
@@ -22,7 +22,7 @@ interface InfoOptionsProps {
 //1-5 truth score radio buttons selection
 function TruthScoreOptions(Prop: TruthScoreOptionsProps) {
   const numberList = Array.from(
-    { length: Prop.numberPointScale },
+    { length: Prop.numberPointScale ?? 6 },
     (_, index) => index + (Prop.numberPointScale === 5 ? 1 : 0)
   );
 


### PR DESCRIPTION
## Issue
- Now that info options depends on numberPointScale value returned in API, it should handle cases where this missing

## Solution
- Fixed