### PR TITLE
rolled back firebase tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir $NVM_DIR && \
     bash $NVM_DIR/nvm.sh ${NODE_VERSION}
 
 # Install firebase-tools and emulators \
-RUN npm i -g firebase-tools && \
+RUN npm i -g firebase-tools@13.20.2 && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \
     firebase setup:emulators:pubsub && \


### PR DESCRIPTION
## Issue
- https://github.com/firebase/firebase-tools/releases/tag/v13.22.0 seems to have broken the firebase emulator. Now its complaining unable to authenticate checkmate-uat

Error: Failed to get Firebase project checkmate-uat. Please make sure the project exists and your account has permission to access it.

## Implementation
- Rolled back to v13.20