### PR TITLE
removed spam from count

### DIFF
--- a/checkers-app/src/components/dashboard/index.tsx
+++ b/checkers-app/src/components/dashboard/index.tsx
@@ -123,9 +123,7 @@ export default function Dashboard() {
               name="Voting Accuracy"
               img_src="/accuracy.png"
               current={
-                programStats.accuracy === null
-                  ? 0
-                  : programStats.accuracy * 100
+                programStats.accuracy === null ? 0 : programStats.accuracy * 100
               }
               target={programStats.accuracyTarget * 100}
               isPercentageTarget={true}
@@ -158,8 +156,9 @@ export default function Dashboard() {
                     >
                       WhatsApp Bot
                     </a>
-                    . You need to submit at least{" "}
-                    {programStats.numReportTarget} messages.
+                    . You need to submit at least {programStats.numReportTarget}{" "}
+                    messages that are not eventually assessed as nvc (can't
+                    tell) or marketing/spam.
                   </>
                 }
               />

--- a/functions/src/definitions/common/responseUtils.ts
+++ b/functions/src/definitions/common/responseUtils.ts
@@ -953,7 +953,11 @@ async function respondToInstance(
   await instanceSnap.ref.update(updateObj)
 
   //check if category does not contain irrelevant, then updated reported number by 1
-  if (category !== "irrelevant" && category !== "irrelevant_auto") {
+  if (
+    category !== "irrelevant" &&
+    category !== "irrelevant_auto" &&
+    category !== "spam"
+  ) {
     //count number of instances from this sender
     const countOfInstancesFromSender = (
       await parentMessageRef


### PR DESCRIPTION
# Pull Request

## Issue Reference

Many checkers are sending in generic marketing messages just to hit the reported quota of 10.

## Description

Stopped counting marketing messages but reduced the count to 5.

## Implementation

1. Changed the final incrementCheckerCounts to ignore cases where category is spam, on top of irrelevant

## Testing

## Additional Notes
---

### Checklist

- [ ] I have linked the issue above using closing keywords if this PR resolves the issue
- [ ] I have provided a description and implementation details
- [ ] I have tested the changes and ensured that they work
