### PR TITLE
3.3.5-hotfix

### DIFF
--- a/functions/src/definitions/common/responseUtils.ts
+++ b/functions/src/definitions/common/responseUtils.ts
@@ -925,7 +925,7 @@ async function respondToInstance(
             language
           )
           const responseText = getFinalResponseText(
-            "UNSURE",
+            responses["UNSURE"],
             responses,
             isImmediate,
             instanceCount,


### PR DESCRIPTION
# PRs
- #486 

# Summary
- Fixed a simple code mistake that lead to unsure response being "UNSURE" rather than responses["UNSURE"]