### PR TITLE
handle inactive upon reaching leaderboard/dashboard

### DIFF
--- a/checkers-app/src/components/common/ReactivationModal.tsx
+++ b/checkers-app/src/components/common/ReactivationModal.tsx
@@ -1,0 +1,78 @@
+// src/components/InactiveUserModal.tsx
+import { useNavigate } from "react-router-dom";
+import {
+  Dialog,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+  Button,
+} from "@material-tailwind/react";
+import { useUser } from "../../providers/UserContext";
+import { activateChecker } from "../../services/api";
+
+interface ReactivationDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onActivation: () => void;
+}
+
+export function ReactivationDialog({
+  open,
+  onClose,
+  onActivation,
+}: ReactivationDialogProps) {
+  const navigate = useNavigate();
+  const { checkerDetails, setCheckerDetails } = useUser();
+
+  const handleCancel = () => {
+    onClose();
+    setCheckerDetails((prev) => ({
+      ...prev,
+      isAgainstReactivating: true,
+    }));
+    navigate("/");
+  };
+
+  const handleReactivation = async () => {
+    try {
+      if (checkerDetails.checkerId) {
+        await activateChecker(checkerDetails.checkerId);
+      }
+      onActivation();
+      onClose();
+    } catch (error) {
+      console.error("Failed to reactivate:", error);
+    }
+  };
+
+  return (
+    <Dialog open={open} handler={onClose} size="xs">
+      <DialogHeader>Welcome Back!</DialogHeader>
+      <DialogBody divider className="space-y-4">
+        <p>Your account is currently inactive. We'd love to have you back!</p>
+        <p className="space-y-2">
+          By reactivating your account, you'll:
+          <ul className="list-disc pl-6 pt-2 space-y-1">
+            <li>Continue your checking journey</li>
+            <li>Receive new messages to vote on</li>
+            <li>Be able to view the leaderboard</li>
+          </ul>
+        </p>
+        <p>Hit the button to get reactivated now!</p>
+      </DialogBody>
+      <DialogFooter>
+        <Button
+          variant="text"
+          color="red"
+          className="border-none"
+          onClick={handleCancel}
+        >
+          Cancel
+        </Button>
+        <Button variant="gradient" color="green" onClick={handleReactivation}>
+          Reactivate
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/checkers-app/src/components/dashboard/index.tsx
+++ b/checkers-app/src/components/dashboard/index.tsx
@@ -16,6 +16,7 @@ import {
   DialogBody,
   DialogFooter,
 } from "@material-tailwind/react";
+import { ReactivationDialog } from "../common/ReactivationModal";
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -32,14 +33,19 @@ export default function Dashboard() {
   const [referralCode, setReferralCode] = useState<string | null>(null);
   const [certificateUrl, setCertificateUrl] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [showReactivationDialog, setShowReactivationDialog] = useState(false);
+
   const handleOpen = () => setDialogOpen(!dialogOpen);
   const handleConfirm = async () => {
     if (!checkerDetails.checkerId) {
       return;
     }
     await withdrawCheckerProgram(checkerDetails.checkerId);
+    setCheckerDetails((prev) => ({
+      ...prev,
+      isAgainstReactivating: true,
+    }));
     setDialogOpen(false);
-    navigate(0);
   };
   const isProd = import.meta.env.MODE === "production";
 
@@ -59,6 +65,10 @@ export default function Dashboard() {
           isActive: checker.isActive,
           certificateUrl: checker.certificateUrl || null,
         }));
+
+        if (!checker.isActive && !checkerDetails.isAgainstReactivating) {
+          setShowReactivationDialog(true);
+        }
 
         if (checker.last30days) {
           setTotalVotes(checker.last30days.totalVoted);
@@ -92,6 +102,13 @@ export default function Dashboard() {
 
   return (
     <div className="flex flex-col gap-y-4 left-right-padding">
+      <ReactivationDialog
+        open={showReactivationDialog}
+        onClose={() => setShowReactivationDialog(false)}
+        onActivation={() => {
+          navigate(0);
+        }}
+      />
       {checkerDetails.pendingCount > 0 && (
         <PendingMessageAlert
           hasPending={true}

--- a/checkers-app/src/components/leaderboard/table.tsx
+++ b/checkers-app/src/components/leaderboard/table.tsx
@@ -13,6 +13,7 @@ import { useUser } from "../../providers/UserContext";
 import Loading from "../common/Loading";
 import { LeaderboardEntry } from "../../types";
 import { getLeaderboard } from "../../services/api";
+import { ReactivationDialog } from "../common/ReactivationModal";
 
 const iconsize = "h-4 w-4";
 const COLUMNS = [
@@ -56,148 +57,169 @@ export function LeaderboardTable() {
   const [abridgedLeaderboard, setAbridgedLeaderboard] = useState<
     LeaderboardEntry[]
   >([]);
-
+  const [showReactivationDialog, setShowReactivationDialog] = useState(false);
+  const fetchLeaderboard = async () => {
+    setIsLoading(true);
+    if (!checkerDetails.checkerId) {
+      return;
+    }
+    const leaderboard: LeaderboardEntry[] = await getLeaderboard(
+      checkerDetails.checkerId
+    );
+    if (leaderboard) {
+      setAbridgedLeaderboard(leaderboard);
+      setIsLoading(false);
+    }
+  };
   useEffect(() => {
-    const fetchLeaderboard = async () => {
-      setIsLoading(true);
-      if (!checkerDetails.checkerId) {
-        return;
-      }
-      const leaderboard: LeaderboardEntry[] = await getLeaderboard(
-        checkerDetails.checkerId
-      );
-      if (leaderboard) {
-        setAbridgedLeaderboard(leaderboard);
-        setIsLoading(false);
-      }
-    };
+    if (!checkerDetails.checkerId) {
+      return;
+    }
+    if (!checkerDetails.isActive) {
+      setShowReactivationDialog(true);
+      setIsLoading(false);
+      return;
+    }
     if (checkerDetails.checkerId) {
       fetchLeaderboard();
     }
   }, [checkerDetails.checkerId]);
+
+  const handleReactivation = async () => {
+    if (checkerDetails.checkerId) {
+      await fetchLeaderboard();
+    }
+  };
 
   if (isLoading) {
     return <Loading />;
   }
 
   return (
-    <Card className="h-full w-full overflow-scroll">
-      <table className="w-full min-w-max table-auto text-left">
-        <thead>
-          <tr>
-            {COLUMNS.map((col) => (
-              <th
-                key={col.title}
-                className="border-b border-blue-gray-100 bg-blue-gray-50 p-4"
-              >
-                <Tooltip content={col.description}>{col.icon}</Tooltip>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {abridgedLeaderboard.map(
-            (
-              {
-                id,
-                position,
-                name,
-                numVoted,
-                accuracy,
-                averageTimeTaken,
-                score,
-              },
-              index
-            ) => {
-              const discontinuity = position - lastIndex > 1;
-              const isChecker = id === checkerDetails.checkerId;
-              const isLast = index === abridgedLeaderboard.length - 1;
-              const rowClasses = isChecker ? "bg-orange-100" : "";
-              const classes = isLast
-                ? "p-4"
-                : "p-4 border-b border-blue-gray-50";
-              lastIndex = position;
+    <>
+      <ReactivationDialog
+        open={showReactivationDialog}
+        onClose={() => setShowReactivationDialog(false)}
+        onActivation={handleReactivation}
+      />
+      <Card className="h-full w-full overflow-scroll">
+        <table className="w-full min-w-max table-auto text-left">
+          <thead>
+            <tr>
+              {COLUMNS.map((col) => (
+                <th
+                  key={col.title}
+                  className="border-b border-blue-gray-100 bg-blue-gray-50 p-4"
+                >
+                  <Tooltip content={col.description}>{col.icon}</Tooltip>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {abridgedLeaderboard.map(
+              (
+                {
+                  id,
+                  position,
+                  name,
+                  numVoted,
+                  accuracy,
+                  averageTimeTaken,
+                  score,
+                },
+                index
+              ) => {
+                const discontinuity = position - lastIndex > 1;
+                const isChecker = id === checkerDetails.checkerId;
+                const isLast = index === abridgedLeaderboard.length - 1;
+                const rowClasses = isChecker ? "bg-orange-100" : "";
+                const classes = isLast
+                  ? "p-4"
+                  : "p-4 border-b border-blue-gray-50";
+                lastIndex = position;
 
-              return (
-                <>
-                  {discontinuity && (
-                    <tr
-                      key={`discontinuity-${position}`}
-                      className="bg-gray-100"
-                    >
-                      <td colSpan={6} className="text-center p-4 italic">
+                return (
+                  <>
+                    {discontinuity && (
+                      <tr
+                        key={`discontinuity-${position}`}
+                        className="bg-gray-100"
+                      >
+                        <td colSpan={6} className="text-center p-4 italic">
+                          <Typography
+                            variant="small"
+                            color="blue-gray"
+                            className="font-normal"
+                          >
+                            ...
+                          </Typography>
+                        </td>
+                      </tr>
+                    )}
+                    <tr key={name} className={rowClasses}>
+                      <td className={classes}>
                         <Typography
                           variant="small"
                           color="blue-gray"
                           className="font-normal"
                         >
-                          ...
+                          {position}
+                        </Typography>
+                      </td>
+                      <td className={classes}>
+                        <Typography
+                          variant="small"
+                          color="blue-gray"
+                          className="font-normal"
+                        >
+                          {name.length > 10 ? `${name.slice(0, 10)}..` : name}
+                        </Typography>
+                      </td>
+                      <td className={classes}>
+                        <Typography
+                          variant="small"
+                          color="blue-gray"
+                          className="font-normal"
+                        >
+                          {numVoted}
+                        </Typography>
+                      </td>
+                      <td className={classes}>
+                        <Typography
+                          variant="small"
+                          color="blue-gray"
+                          className="font-normal"
+                        >
+                          {(accuracy * 100).toFixed(0)}
+                        </Typography>
+                      </td>
+                      <td className={classes}>
+                        <Typography
+                          variant="small"
+                          color="blue-gray"
+                          className="font-normal"
+                        >
+                          {(averageTimeTaken / 60).toFixed(2)}
+                        </Typography>
+                      </td>
+                      <td className={classes}>
+                        <Typography
+                          variant="small"
+                          color="blue-gray"
+                          className="font-bold"
+                        >
+                          {score.toFixed(1)}
                         </Typography>
                       </td>
                     </tr>
-                  )}
-                  <tr key={name} className={rowClasses}>
-                    <td className={classes}>
-                      <Typography
-                        variant="small"
-                        color="blue-gray"
-                        className="font-normal"
-                      >
-                        {position}
-                      </Typography>
-                    </td>
-                    <td className={classes}>
-                      <Typography
-                        variant="small"
-                        color="blue-gray"
-                        className="font-normal"
-                      >
-                        {name.length > 10 ? `${name.slice(0, 10)}..` : name}
-                      </Typography>
-                    </td>
-                    <td className={classes}>
-                      <Typography
-                        variant="small"
-                        color="blue-gray"
-                        className="font-normal"
-                      >
-                        {numVoted}
-                      </Typography>
-                    </td>
-                    <td className={classes}>
-                      <Typography
-                        variant="small"
-                        color="blue-gray"
-                        className="font-normal"
-                      >
-                        {(accuracy * 100).toFixed(0)}
-                      </Typography>
-                    </td>
-                    <td className={classes}>
-                      <Typography
-                        variant="small"
-                        color="blue-gray"
-                        className="font-normal"
-                      >
-                        {(averageTimeTaken / 60).toFixed(2)}
-                      </Typography>
-                    </td>
-                    <td className={classes}>
-                      <Typography
-                        variant="small"
-                        color="blue-gray"
-                        className="font-bold"
-                      >
-                        {score.toFixed(1)}
-                      </Typography>
-                    </td>
-                  </tr>
-                </>
-              );
-            }
-          )}
-        </tbody>
-      </table>
-    </Card>
+                  </>
+                );
+              }
+            )}
+          </tbody>
+        </table>
+      </Card>
+    </>
   );
 }

--- a/checkers-app/src/components/vote/InfoOptions.tsx
+++ b/checkers-app/src/components/vote/InfoOptions.tsx
@@ -63,13 +63,6 @@ export default function InfoOptions(Prop: InfoOptionsProps) {
     <div>
       {
         <>
-          <Alert color="amber">
-            {" "}
-            {/* REMOVE EVENTUALLY */}
-            <span className="font-bold">
-              NOTE: Scale has changed from 1-5 to 0-5!
-            </span>
-          </Alert>
           <Typography className="text-primary-color text-justify my-3">
             Please assess the veracity of the claim(s) in the message on a scale
             from 0 (entirely false) to 5 (entirely true).

--- a/checkers-app/src/types.d.ts
+++ b/checkers-app/src/types.d.ts
@@ -19,6 +19,7 @@ interface CheckerDetails {
   tier: string;
   isActive: boolean;
   certificateUrl?: string | null;
+  isAgainstReactivating?: boolean;
 }
 
 interface Window {

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -244,7 +244,6 @@ export type CheckerData = {
   onboardingStatus:
     | "name"
     | "number"
-    | "otpSent"
     | "verify"
     | "quiz"
     | "onboardWhatsapp"


### PR DESCRIPTION
# Pull Request to Deploy to UAT

## Issue Reference

<!--
Please reference the issue this PR addresses.
If the issue is resolved by this PR, use a closing keyword like:
- Closes #[ISSUE_NUMBER]
- Fixes #[ISSUE_NUMBER]
- Resolves #[ISSUE_NUMBER]
-->

- Resolves #500

## Description

<!-- Provide a brief description of what this PR does -->

Frontend changes to check checkerActivity status before letting them access the leaderboard API. Also did the same for the dashboard page.

## Implementation

1. Created new checker data item isAgainstReactiviating in frontend to track if the checker cancelled the reactivation request
2. Created new dialog modal for reactivating the checker
3. Check for isActive before showing popup modal in leaderboard page
4. Check for isActive and isAgainstReactivating before showing popup modal in dashboard page.
5. Also removed old alert informing checkers that scale had shifted from 1-5 to 0-5


## Testing

<!-- Briefly describe any tests written or run to validate the changes -->

- [x] Tests for new functionality are passing
- [x] Manual testing completed and passed

## Additional Notes

<!-- Add any additional information or context related to the PR -->

---

### Checklist

- [x] I have linked the issue above using closing keywords if this PR resolves the issue
- [x] I have provided a description and implementation details
- [x] I have tested the changes and ensured that they work
