### PR TITLE
shifted completion checks to batchjob

### DIFF
--- a/functions/src/definitions/api/handlers/postChecker.ts
+++ b/functions/src/definitions/api/handlers/postChecker.ts
@@ -84,6 +84,7 @@ const postCheckerHandler = async (req: Request, res: Response) => {
     preferredPlatform: preferredPlatform || (type === "ai" ? null : "telegram"),
     lastVotedTimestamp: lastVotedTimestamp || null,
     getNameMessageId: null,
+    hasReceivedExtension: false,
     hasCompletedProgram: false,
     certificateUrl: null,
     leaderboardStats: {

--- a/functions/src/definitions/eventHandlers/checkerHandlerTelegram.ts
+++ b/functions/src/definitions/eventHandlers/checkerHandlerTelegram.ts
@@ -731,26 +731,6 @@ You may view these resources with the command /resources.`,
     chatId,
     `Hooray! You've now successfully onboarded as a Checker! 🥳 You can chill for now, but stay tuned - you'll receive notifications in this chat when users submit messages for checking. You'll then do the fact-checks on the Checkers' Portal.`
   )
-  // Queue up program completion checks
-  const payload = {
-    checkerId: checkerSnap.id,
-  }
-  const thresholds = await getThresholds()
-  const daysToFirstCompletionCheck =
-    thresholds.daysBeforeFirstCompletionCheck ?? 60
-  const daysToSecondCompletionCheck =
-    thresholds.daysBeforeSecondCompletionCheck ?? 90
-  logger.log(`Enqueuing completion checks for checker ${checkerSnap.id}`)
-  await enqueueTask(
-    payload,
-    "firstCompletionCheck",
-    daysToFirstCompletionCheck * 24 * 60 * 60 + 300
-  ) //first completion check 60 days later. Add 300 so that we can test in UAT
-  await enqueueTask(
-    payload,
-    "secondCompletionCheck",
-    daysToSecondCompletionCheck * 24 * 60 * 60 + 600
-  ) //second completion check 90 days later. Add 600 so that we can test in UAT
 }
 //TODO: edit this to allow checking against diff idfields
 const checkCheckerIsUser = async (whatsappId: string) => {
@@ -803,6 +783,7 @@ const createChecker = async (
         preferredPlatform: "telegram",
         lastVotedTimestamp: null,
         getNameMessageId: null,
+        hasReceivedExtension: false,
         hasCompletedProgram: false,
         certificateUrl: null,
         leaderboardStats: {

--- a/functions/src/definitions/eventHandlers/checkerHandlerWhatsapp.ts
+++ b/functions/src/definitions/eventHandlers/checkerHandlerWhatsapp.ts
@@ -143,6 +143,7 @@ async function onSignUp(from: string, platform = "whatsapp") {
     preferredPlatform: "whatsapp",
     getNameMessageId: res.data.messages[0].id,
     lastVotedTimestamp: null,
+    hasReceivedExtension: false,
     hasCompletedProgram: false,
     certificateUrl: null,
     leaderboardStats: {

--- a/functions/src/definitions/webhookHandlers/specialCommands.ts
+++ b/functions/src/definitions/webhookHandlers/specialCommands.ts
@@ -133,6 +133,7 @@ const mockDb = async function () {
       runtimeEnvironment.value() === "SIT" ? "whatsapp" : "telegram",
     lastVotedTimestamp: null,
     getNameMessageId: null,
+    hasReceivedExtension: false,
     hasCompletedProgram: false,
     certificateUrl: null, // Initialize certificateUrl as an empty string
     leaderboardStats: {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -22,6 +22,4 @@ export { apiHandler } from "./definitions/api/api"
 export { internalApiHandler } from "./definitions/api/apiInternal"
 export { passVoteRequest } from "./definitions/taskHandlers/autoPass"
 export { sendCheckerReactivation } from "./definitions/taskHandlers/reactivations"
-export { firstCompletionCheck } from "./definitions/taskHandlers/firstCompletionCheck"
-export { secondCompletionCheck } from "./definitions/taskHandlers/secondCompletionCheck"
 export { batchJobs }

--- a/functions/src/services/checker/nudgeService.ts
+++ b/functions/src/services/checker/nudgeService.ts
@@ -43,8 +43,18 @@ export async function sendNudge(
   type: string,
   replaceParams: { [key: string]: string },
   ctaButtonText: string | null = null,
-  callbackDataText: string | null = null
+  callbackDataText: string | null = null,
+  onlyOnceReceipt = false
 ): Promise<ServiceResponse> {
+  if (onlyOnceReceipt) {
+    const nudgeResponse = await checkNudgeStatus(docSnap.ref, type)
+    const hasBeenNudged = nudgeResponse.data?.hasBeenNudged ?? true
+    if (hasBeenNudged) {
+      return ServiceResponse.success({
+        message: "Nudge already sent",
+      })
+    }
+  }
   const nudges = await getNudges()
   const nudgeType = type.toUpperCase()
   const response = selectNudge(nudgeType, nudges)

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -259,6 +259,7 @@ export type CheckerData = {
   singpassOpenId: string | null // The Singpass OpenID of the checker, if available. Not yet implemented
   telegramId: number | null // The Telegram ID of the checker
   whatsappId: string | null // The WhatsApp ID of the checker, obtained on onboarding
+  hasReceivedExtension: boolean // Whether the checker has received an extension to complete the program
   hasCompletedProgram: boolean // Whether the checker has completed the CheckMate's program
   certificateUrl?: string | null // The public cloud storage URL of the certificate, if the checker has completed the program
   level: number // The level of the checker, for gamification. Not yet implemented

--- a/functions/src/utils/time.ts
+++ b/functions/src/utils/time.ts
@@ -10,3 +10,9 @@ export enum TIME {
   // 30 days in milliseconds
   THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000,
 }
+
+export function getDateNDaysAgo(daysAgo: number): Date {
+  const date = new Date() // Current date
+  date.setDate(date.getDate() - daysAgo) // Subtract n days
+  return date
+}


### PR DESCRIPTION
# Pull Request to Deploy to UAT

## Issue Reference

<!--
Please reference the issue this PR addresses.
If the issue is resolved by this PR, use a closing keyword like:
- Closes #[ISSUE_NUMBER]
- Fixes #[ISSUE_NUMBER]
- Resolves #[ISSUE_NUMBER]
-->

- Resolves #510

## Description

<!-- Provide a brief description of what this PR does -->

Cloud tasks doesn't support scheduling tasks more than 30 days into the future. Since we require the completion checks to be after 60 and 90 days, we have to implement it a different way. As a result, this was switched to being based on batch-job.

## Implementation

1. Removed cloud task creation and removed cloud task functions for 1st and 2nd completion checks
2. Added new daily batch job to perform the 1st and 2nd completion check
3. Reduced inactivity reminders from 4 to 2 (14, and 28 days) to keep within 30 day limits 

## Testing

<!-- Briefly describe any tests written or run to validate the changes -->

- [ ] Tests for new functionality are passing
- [ ] Manual testing completed and passed

## Additional Notes

<!-- Add any additional information or context related to the PR -->

---

### Checklist

- [ ] I have linked the issue above using closing keywords if this PR resolves the issue
- [ ] I have provided a description and implementation details
- [ ] I have tested the changes and ensured that they work
