### PR TITLE
Feat/checkmate v2 fixes

### DIFF
--- a/functions/src/definitions/webhookHandlers/handler.ts
+++ b/functions/src/definitions/webhookHandlers/handler.ts
@@ -176,7 +176,7 @@ const postHandlerWhatsapp = async (req: Request, res: Response) => {
                     message,
                     "whatsapp"
                   )
-                } else if (!userSnap.get("isOnboardingComplete")) {
+                } else if (userSnap.get("isOnboardingComplete") === false) {
                   await sendOnboardingFlow(userSnap, false)
                   await handlePreOnboardedMessage(userSnap, message)
                   return res.sendStatus(200)

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -249,7 +249,7 @@ export type UserData = {
   language: LanguageSelection // The user's preferred language, either "en" or "cn"
   isSubscribedUpdates: boolean // Whether the user wants to receive proactive updates/messages from CheckMate
   isIgnored: boolean // Whether the user is blocked
-  isOnboardingComplete: boolean // Whether the user has completed the onboarding flow (selected language, age group, agreed to terms of use)
+  isOnboardingComplete: boolean | null // Whether the user has completed the onboarding flow (selected language, age group, agreed to terms of use). Null for legacy users who onboarded before v2.
   numSubmissionsRemaining: number // Number of submissions made in given time period
   submissionLimit: number // Number of submissions allowed in given time period
   isInterestedInSubscription: boolean | null // Whether the user is interested in subscribing to CheckMate's paid tier at $5 a month


### PR DESCRIPTION
# Pull Request to Deploy to UAT

## Issue Reference

People who onboarded before v2 will be met with onboarding message when they send in messages

**Example:**
Resolves #[ISSUE_NUMBER]

## Description

Allow those who onboarded before v2 to continue sending in messages without interruption. One time exercise to get them to do onboarding to follow later.

## Implementation

1. Set all these people's isOnboardingComplete to null (not false)
2. Check for === false instead of just falsy

## Testing

<!-- Briefly describe any tests written or run to validate the changes -->

- [ ] Tests for new functionality are passing
- [ ] Manual testing completed and passed

## Additional Notes

<!-- Add any additional information or context related to the PR -->

---

### Checklist

- [ ] I have linked the issue above using closing keywords if this PR resolves the issue
- [ ] I have provided a description and implementation details
- [ ] I have tested the changes and ensured that they work
