### PR TITLE
sync hasResponse field to typesense

### DIFF
--- a/functions/src/definitions/eventHandlers/updateTypesense.ts
+++ b/functions/src/definitions/eventHandlers/updateTypesense.ts
@@ -50,6 +50,7 @@ const onMessageWriteV2 = onDocumentWritten(
         lastReceivedMonth: lastMonth,
         firstReceivedMonth: firstMonth,
         response,
+        hasResponse: !!response,
         isDownvoted: downvoted,
       }
       try {


### PR DESCRIPTION
# Pull Request to Deploy to UAT

## Issue Reference

Typesense database cannot filter for absense of response field.

**Example:**
Resolves #[ISSUE_NUMBER]

## Description

<!-- Provide a brief description of what this PR does -->

Added a hasResponse field to Typesense

## Implementation

As described

## Testing

<!-- Briefly describe any tests written or run to validate the changes -->

- [ ] Tests for new functionality are passing
- [ ] Manual testing completed and passed

## Additional Notes

<!-- Add any additional information or context related to the PR -->

---

### Checklist

- [ ] I have linked the issue above using closing keywords if this PR resolves the issue
- [ ] I have provided a description and implementation details
- [ ] I have tested the changes and ensured that they work
