### PR TITLE
Feat/handle template buttons

### DIFF
--- a/functions/src/definitions/eventHandlers/userPreOnboardingHandler.ts
+++ b/functions/src/definitions/eventHandlers/userPreOnboardingHandler.ts
@@ -10,6 +10,8 @@ import {
   sendUnsupportedTypeMessage,
   sendCheckSharingMessagePreOnboard,
   handleDisclaimer,
+  sendMenuMessage,
+  sendSharingMessage,
 } from "../../definitions/common/responseUtils"
 import { checkPreV2User } from "../../definitions/common/utils"
 import {
@@ -18,8 +20,13 @@ import {
   GeneralMessage,
 } from "../../types"
 import { determineNeedsChecking } from "../../definitions/common/machineLearningServer/operations"
+import { checkHelp } from "../../validators/whatsapp/checkWhatsappText"
 import { publishToTopic } from "../../definitions/common/pubsub"
 import { getUserSnapshot } from "../../services/user/userManagement"
+import {
+  checkMenu,
+  checkShare,
+} from "../../validators/whatsapp/checkWhatsappText"
 
 if (!admin.apps.length) {
   admin.initializeApp()
@@ -90,6 +97,27 @@ async function handlePreOnboardedMessage(
           if (text === PREPOPULATED_MESSAGE) {
             step = "preonboard_prepopulated"
             //wait 5 seconds before sending onboarding flow
+            await sendCheckMateDemonstration(userSnap)
+            break
+          }
+          if (checkMenu(text)) {
+            step = "text_menu"
+            await sendMenuMessage(
+              userSnap,
+              "MENU_PREFIX",
+              "whatsapp",
+              null,
+              null
+            )
+            break
+          }
+          if (checkShare(text)) {
+            step = "text_share"
+            await sendSharingMessage(userSnap)
+            break
+          }
+          if (checkHelp(text)) {
+            step = "text_help"
             await sendCheckMateDemonstration(userSnap)
             break
           }

--- a/functions/src/definitions/eventHandlers/userPreOnboardingHandler.ts
+++ b/functions/src/definitions/eventHandlers/userPreOnboardingHandler.ts
@@ -27,6 +27,7 @@ import {
   checkMenu,
   checkShare,
 } from "../../validators/whatsapp/checkWhatsappText"
+import { onTemplateButtonReply } from "./userNavigationHandlers"
 
 if (!admin.apps.length) {
   admin.initializeApp()
@@ -155,6 +156,10 @@ async function handlePreOnboardedMessage(
               step = await onPreOnboardButtonReply(userSnap, message)
               break
           }
+          break
+
+        case "button":
+          await onTemplateButtonReply(userSnap, message)
           break
         default:
           step = "preonboard_unsupported"
@@ -308,4 +313,4 @@ const onUserPreOnboardingPublish = onMessagePublished(
   }
 )
 
-export { onUserPreOnboardingPublish }
+export { onUserPreOnboardingPublish, SAMPLE_MESSAGES }


### PR DESCRIPTION
# Pull Request to Deploy to UAT

## Issue Reference

- Support message blasts on 17 May 2025 for onboarding.
- Make / commands work in pre-onboarding

## Description

Support more template buttons
Standardise across both pre and post-onboarding for /commands and template message handling

A clear and concise description of what changes were made to address the issue.

## Implementation

As above

## Testing

<!-- Briefly describe any tests written or run to validate the changes -->

- [ ] Tests for new functionality are passing
- [ ] Manual testing completed and passed

## Additional Notes

<!-- Add any additional information or context related to the PR -->

---

### Checklist

- [ ] I have linked the issue above using closing keywords if this PR resolves the issue
- [ ] I have provided a description and implementation details
- [ ] I have tested the changes and ensured that they work
