### PR TITLE
Feat/handle postonboard sample message response

### DIFF
--- a/functions/src/definitions/webhookHandlers/handler.ts
+++ b/functions/src/definitions/webhookHandlers/handler.ts
@@ -185,23 +185,11 @@ const postHandlerWhatsapp = async (req: Request, res: Response) => {
                     userSnap.get("isOnboardingComplete") === false &&
                     !isFlowSubmission
                   ) {
-                    switch (type) {
-                      case "text":
-                      case "image":
-                      case "button":
-                      case "interactive":
-                        // Publish to queue instead of direct handling
-                        await publishToTopic(
-                          "userPreOnboardingEvents",
-                          message,
-                          "whatsapp"
-                        )
-                        break
-                      default:
-                        await sendUnsupportedTypeMessage(userSnap, message.id)
-                        break
-                    }
-
+                    await publishToTopic(
+                      "userPreOnboardingEvents",
+                      message,
+                      "whatsapp"
+                    )
                     return res.sendStatus(200)
                   }
                   //check whether it's navigational or message

--- a/functions/src/definitions/webhookHandlers/handler.ts
+++ b/functions/src/definitions/webhookHandlers/handler.ts
@@ -188,6 +188,7 @@ const postHandlerWhatsapp = async (req: Request, res: Response) => {
                     switch (type) {
                       case "text":
                       case "image":
+                      case "button":
                       case "interactive":
                         // Publish to queue instead of direct handling
                         await publishToTopic(


### PR DESCRIPTION
# Pull Request to Deploy to UAT

## Issue Reference

- If user has used up preOnboardingSubmissions, even non-text and non-image interactions result in them being asked to signup.

## Description

Only apply the above check at non-interaction messages.

## Implementation

As above

## Testing

<!-- Briefly describe any tests written or run to validate the changes -->

- [ ] Tests for new functionality are passing
- [ ] Manual testing completed and passed

## Additional Notes

<!-- Add any additional information or context related to the PR -->

---

### Checklist

- [ ] I have linked the issue above using closing keywords if this PR resolves the issue
- [ ] I have provided a description and implementation details
- [ ] I have tested the changes and ensured that they work
