### PR TITLE
fix: fix instance not updated properly when category unsure

### DIFF
--- a/functions/src/definitions/common/responseUtils.ts
+++ b/functions/src/definitions/common/responseUtils.ts
@@ -1472,7 +1472,7 @@ async function respondToInstance(
             parentMessageRef,
             language
           )
-          const responseText = getFinalResponseText({
+          responseText = getFinalResponseText({
             responseText: responses["UNSURE"],
             responses,
             submissionsUsed: numSubmissionsUsed,


### PR DESCRIPTION
# Pull Request to Deploy to UAT

## Issue Reference

<!--
Please reference the issue this PR addresses.
If the issue is resolved by this PR, use a closing keyword like:
- Closes #[ISSUE_NUMBER]
- Fixes #[ISSUE_NUMBER]
- Resolves #[ISSUE_NUMBER]
-->

Resolves #634 

## Description

<!-- Provide a brief description of what this PR does -->

Additional const keyword means global variable not set properly

## Implementation

>   The fix: The responseText defined inside the "unsure" case block (lines 1475-1488) needs to be assigned to the outer responseText variable declared at line 1258.
> 
>   Change line 1475 from:
>   const responseText = getFinalResponseText({
>   to:
>   responseText = getFinalResponseText({
> 
>   This ensures the outer responseText variable is set before the break statement, making it available for the database update at line 1543.
> 
> > check now. have i fixed the issue?
> 
> ⏺ Yes, you've fixed the issue!
> 
>   By changing line 1475 from const responseText to just responseText, you're now correctly assigning to the outer responseText variable that was declared at line 1258.
> 
>   This means when the code breaks at line 1494 and later reaches line 1543 where it sets updateObj.finalReplyText = responseText, the responseText variable will have the proper value instead of being undefined.
> 
>   This should resolve the error you were seeing in your logs where finalReplyText was undefined for the "unsure" category when neither isHarmful nor isHarmless is true.

## Testing

<!-- Briefly describe any tests written or run to validate the changes -->

- [ ] Tests for new functionality are passing
- [ ] Manual testing completed and passed

## Additional Notes

<!-- Add any additional information or context related to the PR -->

---

### Checklist

- [ ] I have linked the issue above using closing keywords if this PR resolves the issue
- [ ] I have provided a description and implementation details
- [ ] I have tested the changes and ensured that they work
